### PR TITLE
Fixed bug 4108 - Missing break statements in SDL_CDResume and SDL_CDStop

### DIFF
--- a/src/cdrom/SDL_cdrom.c
+++ b/src/cdrom/SDL_cdrom.c
@@ -285,6 +285,7 @@ int SDL_CDResume(SDL_CD *cdrom)
 	switch (status) {
 		case CD_PAUSED:
 			retval = SDL_CDcaps.Resume(cdrom);
+			break;
 		default:
 			retval = 0;
 			break;
@@ -307,6 +308,7 @@ int SDL_CDStop(SDL_CD *cdrom)
 		case CD_PLAYING:
 		case CD_PAUSED:
 			retval = SDL_CDcaps.Stop(cdrom);
+			break;
 		default:
 			retval = 0;
 			break;


### PR DESCRIPTION
Ozkan Sezer

Two break statements are missing in SDL_cdrom.c:SDL_CDResume()
and SDL_CDStop(), which negate the returned code from driver
and always return 0.  The following patch adds those breaks.

--HG--
branch : SDL-1.2