### PR TITLE
Native AmigaOS4 Makefile

### DIFF
--- a/Makefile.amigaos4
+++ b/Makefile.amigaos4
@@ -24,6 +24,10 @@ SOURCES = \
 	./src/joystick/*.c \
 	./src/joystick/amigaos4/*.c \
 	./src/loadso/amigaos4/*.c \
+	./src/render/*.c \
+	./src/render/amigaos4/*.c \
+	./src/render/opengl/*.c \
+	./src/render/software/*.c \
 	./src/sensor/*.c \
 	./src/sensor/dummy/*.c \
 	./src/stdlib/*.c \

--- a/Makefile.amigaos4
+++ b/Makefile.amigaos4
@@ -6,7 +6,7 @@ CC = ppc-amigaos-gcc
 CXX = ppc-amigaos-g++
 STRIP = ppc-amigaos-strip
 
-CFLAGS  = -Wall -fPIC -I./include -maltivec
+CFLAGS  = -g -O2 -Wall -fPIC -I./include
 
 TARGET_STATIC  = libSDL2.a
 TARGET_SHARED  = libSDL2-2.0.so

--- a/Makefile.amigaos4
+++ b/Makefile.amigaos4
@@ -28,7 +28,6 @@ SOURCES = \
 	./src/loadso/amigaos4/*.c \
 	./src/render/*.c \
 	./src/power/*.c \
-	./src/power/*.c \
 	./src/render/amigaos4/*.c \
 	./src/render/opengl/*.c \
 	./src/render/opengles2/*.c \

--- a/Makefile.amigaos4
+++ b/Makefile.amigaos4
@@ -1,0 +1,64 @@
+# Makefile to build the AmigaOS4 SDL library
+
+AR = ppc-amigaos-ar
+RANLIB = ppc-amigaos-ranlib
+CC = ppc-amigaos-gcc
+CXX = ppc-amigaos-g++
+STRIP = ppc-amigaos-strip
+
+CFLAGS  = -Wall -fPIC -I./include -maltivec
+
+TARGET_STATIC  = libSDL2.a
+TARGET_SHARED  = libSDL2-2.0.so
+
+SOURCES = \
+	./src/*.c \
+	./src/audio/*.c \
+	./src/audio/amigaos4/*.c \
+	./src/audio/dummy/*.c \
+	./src/cpuinfo/*.c \
+	./src/events/*.c \
+	./src/file/*.c \
+	./src/haptic/*.c \
+	./src/haptic/dummy/*.c \
+	./src/joystick/*.c \
+	./src/joystick/amigaos4/*.c \
+	./src/loadso/amigaos4/*.c \
+	./src/sensor/*.c \
+	./src/sensor/dummy/*.c \
+	./src/stdlib/*.c \
+	./src/thread/*.c \
+	./src/thread/generic/SDL_syssem.c \
+	./src/thread/pthread/SDL_syscond.c \
+	./src/thread/pthread/SDL_sysmutex.c \
+	./src/thread/pthread/SDL_systhread.c \
+	./src/timer/*.c \
+	./src/timer/unix/*.c \
+	./src/video/*.c \
+	./src/video/dummy/*.c \
+	./src/video/amigaos4/*.c \
+	
+
+OBJECTS = $(shell echo $(SOURCES) | sed -e 's,\.c,\.o,g')
+
+all: config_copy $(TARGET_STATIC) $(TARGET_SHARED)
+
+$(TARGET_STATIC): $(OBJECTS)
+	$(AR) crv $@ $^
+	$(RANLIB) $@
+
+$(TARGET_SHARED):
+	$(CC) -shared -Wl,-soname,$(TARGET_SHARED) -o $(TARGET_SHARED)  $(OBJECTS)
+
+config_copy:
+	cp include/SDL_config_amigaos4.h include/SDL_config.h
+
+clean:
+	rm -f $(TARGET_STATIC) $(TARGET_SHARED)* $(OBJECTS)
+
+install:
+	mkdir -p /SDK/local/newlib/lib
+	mkdir -p /SDK/local/newlib/include/SDL2
+	cp -f $(TARGET_STATIC) /SDK/local/newlib/lib
+	cp -f $(TARGET_SHARED) /SDK/local/newlib/lib
+	cp -f include/*.h /SDK/local/newlib/include/SDL2/

--- a/Makefile.amigaos4
+++ b/Makefile.amigaos4
@@ -13,20 +13,25 @@ TARGET_SHARED  = libSDL2-2.0.so
 
 SOURCES = \
 	./src/*.c \
+	./src/atomic/*.c \
 	./src/audio/*.c \
 	./src/audio/amigaos4/*.c \
 	./src/audio/dummy/*.c \
 	./src/cpuinfo/*.c \
 	./src/events/*.c \
 	./src/file/*.c \
+	./src/filesystem/amigaos4/*.c \
 	./src/haptic/*.c \
 	./src/haptic/dummy/*.c \
 	./src/joystick/*.c \
 	./src/joystick/amigaos4/*.c \
 	./src/loadso/amigaos4/*.c \
 	./src/render/*.c \
+	./src/power/*.c \
+	./src/power/*.c \
 	./src/render/amigaos4/*.c \
 	./src/render/opengl/*.c \
+	./src/render/opengles2/*.c \
 	./src/render/software/*.c \
 	./src/sensor/*.c \
 	./src/sensor/dummy/*.c \
@@ -36,11 +41,14 @@ SOURCES = \
 	./src/thread/pthread/SDL_syscond.c \
 	./src/thread/pthread/SDL_sysmutex.c \
 	./src/thread/pthread/SDL_systhread.c \
+	./src/thread/pthread/SDL_systls.c \
+	./src/test/*.c \
 	./src/timer/*.c \
 	./src/timer/unix/*.c \
 	./src/video/*.c \
 	./src/video/dummy/*.c \
 	./src/video/amigaos4/*.c \
+	./src/video/yuv2rgb/*.c \
 	
 
 OBJECTS = $(shell echo $(SOURCES) | sed -e 's,\.c,\.o,g')

--- a/include/SDL_config_amigaos4.h
+++ b/include/SDL_config_amigaos4.h
@@ -347,7 +347,7 @@
 /* #undef SDL_VIDEO_RENDER_D3D11 */
 #define SDL_VIDEO_RENDER_OGL 1
 /* #undef SDL_VIDEO_RENDER_OGL_ES */
-/* #undef SDL_VIDEO_RENDER_OGL_ES2 */
+#define SDL_VIDEO_RENDER_OGL_ES2 1
 /* #undef SDL_VIDEO_RENDER_DIRECTFB */
 /* #undef SDL_VIDEO_RENDER_METAL */
 #define SDL_VIDEO_RENDER_AMIGAOS4 1
@@ -355,7 +355,7 @@
 /* Enable OpenGL support */
 #define SDL_VIDEO_OPENGL 1
 /* #undef SDL_VIDEO_OPENGL_ES */
-/* #undef SDL_VIDEO_OPENGL_ES2 */
+#define SDL_VIDEO_OPENGL_ES2 1
 /* #undef SDL_VIDEO_OPENGL_BGL */
 /* #undef SDL_VIDEO_OPENGL_CGL */
 /* #undef SDL_VIDEO_OPENGL_EGL */

--- a/include/SDL_config_amigaos4.h
+++ b/include/SDL_config_amigaos4.h
@@ -1,0 +1,403 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_config_amigaos4_h_
+#define SDL_config_amigaos4_h_
+#define SDL_config_h_
+
+/* This is a set of defines to configure the SDL features */
+
+/* General platform specific identifiers */
+#include "SDL_platform.h"
+
+/* C datatypes */
+#ifdef __LP64__
+#define SIZEOF_VOIDP 8
+#else
+#define SIZEOF_VOIDP 4
+#endif
+#define HAVE_GCC_ATOMICS 1
+/* #undef HAVE_GCC_SYNC_LOCK_TEST_AND_SET */
+
+/* Useful headers */
+#define STDC_HEADERS 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
+#define HAVE_ICONV_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MATH_H 1
+/* #undef HAVE_MEMORY_H */
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_WCHAR_H 1
+/* #undef HAVE_PTHREAD_NP_H */
+/* #undef HAVE_LIBUNWIND_H */
+
+/* C library functions */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#define HAVE_ALLOCA 1
+#ifndef __WIN32__ /* Don't use C runtime versions of these on Windows */
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_PUTENV 1
+/* #undef HAVE_UNSETENV */
+#endif
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_BCOPY 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+/* #undef HAVE_MEMCMP */
+#define HAVE_WCSLEN 1
+/* #undef HAVE_WCSLCPY */
+/* #undef HAVE_WCSLCAT */
+#define HAVE_WCSCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRLCPY 1
+#define HAVE_STRLCAT 1
+/* #undef HAVE__STRREV */
+/* #undef HAVE__STRUPR */
+/* #undef HAVE__STRLWR */
+/* #undef HAVE_INDEX */
+/* #undef HAVE_RINDEX */
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+/* #undef HAVE_ITOA */
+/* #undef HAVE__LTOA */
+/* #undef HAVE__UITOA */
+/* #undef HAVE__ULTOA */
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+/* #undef HAVE__I64TOA */
+/* #undef HAVE__UI64TOA */
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+/* #undef HAVE_STRTOD */
+#define HAVE_ATOI 1
+#define HAVE_ATOF 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+/* #undef HAVE__STRICMP */
+#define HAVE_STRCASECMP 1
+/* #undef HAVE__STRNICMP */
+#define HAVE_STRNCASECMP 1
+/* #undef HAVE_SSCANF */
+#define HAVE_VSSCANF 1
+/* #undef HAVE_SNPRINTF */
+#define HAVE_VSNPRINTF 1
+#define HAVE_M_PI /**/
+#define HAVE_ACOS 1
+#define HAVE_ACOSF 1
+#define HAVE_ASIN 1
+#define HAVE_ASINF 1
+#define HAVE_ATAN 1
+#define HAVE_ATANF 1
+#define HAVE_ATAN2 1
+#define HAVE_ATAN2F 1
+#define HAVE_CEIL 1
+#define HAVE_CEILF 1
+#define HAVE_COPYSIGN 1
+#define HAVE_COPYSIGNF 1
+#define HAVE_COS 1
+#define HAVE_COSF 1
+#define HAVE_EXP 1
+#define HAVE_EXPF 1
+#define HAVE_FABS 1
+#define HAVE_FABSF 1
+#define HAVE_FLOOR 1
+#define HAVE_FLOORF 1
+#define HAVE_FMOD 1
+#define HAVE_FMODF 1
+#define HAVE_LOG 1
+#define HAVE_LOGF 1
+#define HAVE_LOG10 1
+#define HAVE_LOG10F 1
+#define HAVE_POW 1
+#define HAVE_POWF 1
+#define HAVE_SCALBN 1
+#define HAVE_SCALBNF 1
+#define HAVE_SIN 1
+#define HAVE_SINF 1
+#define HAVE_SQRT 1
+#define HAVE_SQRTF 1
+#define HAVE_TAN 1
+#define HAVE_TANF 1
+#define HAVE_FOPEN64 1
+#define HAVE_FSEEKO 1
+#define HAVE_FSEEKO64 1
+/* #undef HAVE_SIGACTION */
+/* #undef HAVE_SA_SIGACTION */
+#define HAVE_SETJMP 1
+/* #undef HAVE_NANOSLEEP */
+/* #undef HAVE_SYSCONF */
+/* #undef HAVE_SYSCTLBYNAME */
+/* #undef HAVE_CLOCK_GETTIME */
+/* #undef HAVE_GETPAGESIZE */
+/* #undef HAVE_MPROTECT */
+#define HAVE_ICONV 1
+/* #undef HAVE_PTHREAD_SETNAME_NP */
+/* #undef HAVE_PTHREAD_SET_NAME_NP */
+/* #undef HAVE_SEM_TIMEDWAIT */
+/* #undef HAVE_GETAUXVAL */
+/* #undef HAVE_POLL */
+
+
+#define HAVE_ALTIVEC_H 1
+/* #undef HAVE_DBUS_DBUS_H */
+/* #undef HAVE_FCITX_FRONTEND_H */
+/* #undef HAVE_IBUS_IBUS_H */
+/* #undef HAVE_IMMINTRIN_H */
+/* #undef HAVE_LIBSAMPLERATE_H */
+/* #undef HAVE_LIBUDEV_H */
+
+/* #undef HAVE_DDRAW_H */
+/* #undef HAVE_DINPUT_H */
+/* #undef HAVE_DSOUND_H */
+/* #undef HAVE_DXGI_H */
+/* #undef HAVE_XINPUT_H */
+/* #undef HAVE_ENDPOINTVOLUME_H */
+/* #undef HAVE_MMDEVICEAPI_H */
+/* #undef HAVE_AUDIOCLIENT_H */
+/* #undef HAVE_XINPUT_GAMEPAD_EX */
+/* #undef HAVE_XINPUT_STATE_EX */
+
+/* SDL internal assertion support */
+/* #undef SDL_DEFAULT_ASSERT_LEVEL */
+
+/* Allow disabling of core subsystems */
+/* #undef SDL_ATOMIC_DISABLED */
+/* #undef SDL_AUDIO_DISABLED */
+/* #undef SDL_CPUINFO_DISABLED */
+/* #undef SDL_EVENTS_DISABLED */
+/* #undef SDL_FILE_DISABLED */
+/* #undef SDL_JOYSTICK_DISABLED */
+/* #undef SDL_HAPTIC_DISABLED */
+/* #undef SDL_SENSOR_DISABLED */
+/* #undef SDL_LOADSO_DISABLED */
+/* #undef SDL_RENDER_DISABLED */
+/* #undef SDL_THREADS_DISABLED */
+/* #undef SDL_TIMERS_DISABLED */
+/* #undef SDL_VIDEO_DISABLED */
+/* #undef SDL_POWER_DISABLED */
+/* #undef SDL_FILESYSTEM_DISABLED */
+
+/* Enable various audio drivers */
+/* #undef SDL_AUDIO_DRIVER_ALSA */
+/* #undef SDL_AUDIO_DRIVER_ALSA_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_ANDROID */
+/* #undef SDL_AUDIO_DRIVER_ARTS */
+/* #undef SDL_AUDIO_DRIVER_ARTS_DYNAMIC */
+#define SDL_AUDIO_DRIVER_AMIGAOS4 1
+/* #undef SDL_AUDIO_DRIVER_COREAUDIO */
+/* #undef SDL_AUDIO_DRIVER_DISK */
+/* #undef SDL_AUDIO_DRIVER_DSOUND */
+#define SDL_AUDIO_DRIVER_DUMMY 1
+/* #undef SDL_AUDIO_DRIVER_EMSCRIPTEN */
+/* #undef SDL_AUDIO_DRIVER_ESD */
+/* #undef SDL_AUDIO_DRIVER_ESD_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_FUSIONSOUND */
+/* #undef SDL_AUDIO_DRIVER_FUSIONSOUND_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_HAIKU */
+/* #undef SDL_AUDIO_DRIVER_JACK */
+/* #undef SDL_AUDIO_DRIVER_JACK_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_NACL */
+/* #undef SDL_AUDIO_DRIVER_NAS */
+/* #undef SDL_AUDIO_DRIVER_NAS_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_NETBSD */
+/* #undef SDL_AUDIO_DRIVER_OSS */
+/* #undef SDL_AUDIO_DRIVER_OSS_SOUNDCARD_H */
+/* #undef SDL_AUDIO_DRIVER_PAUDIO */
+/* #undef SDL_AUDIO_DRIVER_PULSEAUDIO */
+/* #undef SDL_AUDIO_DRIVER_PULSEAUDIO_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_QSA */
+/* #undef SDL_AUDIO_DRIVER_SNDIO */
+/* #undef SDL_AUDIO_DRIVER_SNDIO_DYNAMIC */
+/* #undef SDL_AUDIO_DRIVER_SUNAUDIO */
+/* #undef SDL_AUDIO_DRIVER_WASAPI */
+/* #undef SDL_AUDIO_DRIVER_WINMM */
+
+/* Enable various input drivers */
+/* #undef SDL_INPUT_LINUXEV */
+/* #undef SDL_INPUT_LINUXKD */
+/* #undef SDL_INPUT_TSLIB */
+/* #undef SDL_JOYSTICK_HAIKU */
+#define SDL_JOYSTICK_AMIGAINPUT 1
+/* #undef SDL_JOYSTICK_DINPUT */
+/* #undef SDL_JOYSTICK_XINPUT */
+/* #undef SDL_JOYSTICK_DUMMY */
+/* #undef SDL_JOYSTICK_IOKIT */
+/* #undef SDL_JOYSTICK_LINUX */
+/* #undef SDL_JOYSTICK_ANDROID */
+/* #undef SDL_JOYSTICK_WINMM */
+/* #undef SDL_JOYSTICK_USBHID */
+/* #undef SDL_JOYSTICK_USBHID_MACHINE_JOYSTICK_H */
+/* #undef SDL_JOYSTICK_HIDAPI */
+/* #undef SDL_JOYSTICK_EMSCRIPTEN */
+#define SDL_HAPTIC_DUMMY 1
+/* #undef SDL_HAPTIC_ANDROID */
+/* #undef SDL_HAPTIC_LINUX */
+/* #undef SDL_HAPTIC_IOKIT */
+/* #undef SDL_HAPTIC_DINPUT */
+/* #undef SDL_HAPTIC_XINPUT */
+
+/* Enable various sensor drivers */
+/* #undef SDL_SENSOR_ANDROID */
+#define SDL_SENSOR_DUMMY 1
+
+/* Enable various shared object loading systems */
+/* #undef SDL_LOADSO_DLOPEN */
+/* #undef SDL_LOADSO_DUMMY */
+/* #undef SDL_LOADSO_LDG */
+/* #undef SDL_LOADSO_WINDOWS */
+#define SDL_LOADSO_AMIGAOS4 1
+
+/* Enable various threading systems */
+#define SDL_THREAD_PTHREAD 1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX 1
+/* #undef SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP */
+/* #undef SDL_THREAD_WINDOWS */
+/* #undef SDL_THREAD_AMIGAOS4 */
+
+/* Enable various timer systems */
+/* #undef SDL_TIMER_HAIKU */
+/* #undef SDL_TIMER_AMIGAOS4 */
+/* #undef SDL_TIMER_DUMMY */
+#define SDL_TIMER_UNIX 1
+/* #undef SDL_TIMER_WINDOWS */
+
+/* Enable various video drivers */
+/* #undef SDL_VIDEO_DRIVER_HAIKU */
+#define SDL_VIDEO_DRIVER_AMIGAOS4 1
+/* #undef SDL_VIDEO_DRIVER_COCOA */
+/* #undef SDL_VIDEO_DRIVER_DIRECTFB */
+/* #undef SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC */
+#define SDL_VIDEO_DRIVER_DUMMY 1
+/* #undef SDL_VIDEO_DRIVER_WINDOWS */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR */
+/* #undef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON */
+/* #undef SDL_VIDEO_DRIVER_X11 */
+/* #undef SDL_VIDEO_DRIVER_RPI */
+/* #undef SDL_VIDEO_DRIVER_KMSDRM */
+/* #undef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC */
+/* #undef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC_GBM */
+/* #undef SDL_VIDEO_DRIVER_ANDROID */
+/* #undef SDL_VIDEO_DRIVER_EMSCRIPTEN */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XEXT */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XCURSOR */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINERAMA */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2 */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XRANDR */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XSS */
+/* #undef SDL_VIDEO_DRIVER_X11_DYNAMIC_XVIDMODE */
+/* #undef SDL_VIDEO_DRIVER_X11_XCURSOR */
+/* #undef SDL_VIDEO_DRIVER_X11_XDBE */
+/* #undef SDL_VIDEO_DRIVER_X11_XINERAMA */
+/* #undef SDL_VIDEO_DRIVER_X11_XINPUT2 */
+/* #undef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH */
+/* #undef SDL_VIDEO_DRIVER_X11_XRANDR */
+/* #undef SDL_VIDEO_DRIVER_X11_XSCRNSAVER */
+/* #undef SDL_VIDEO_DRIVER_X11_XSHAPE */
+/* #undef SDL_VIDEO_DRIVER_X11_XVIDMODE */
+/* #undef SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS */
+/* #undef SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY */
+/* #undef SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM */
+/* #undef SDL_VIDEO_DRIVER_NACL */
+/* #undef SDL_VIDEO_DRIVER_VIVANTE */
+/* #undef SDL_VIDEO_DRIVER_VIVANTE_VDK */
+/* #undef SDL_VIDEO_DRIVER_QNX */
+
+/* #undef SDL_VIDEO_RENDER_D3D */
+/* #undef SDL_VIDEO_RENDER_D3D11 */
+#define SDL_VIDEO_RENDER_OGL 1
+/* #undef SDL_VIDEO_RENDER_OGL_ES */
+/* #undef SDL_VIDEO_RENDER_OGL_ES2 */
+/* #undef SDL_VIDEO_RENDER_DIRECTFB */
+/* #undef SDL_VIDEO_RENDER_METAL */
+#define SDL_VIDEO_RENDER_AMIGAOS4 1
+
+/* Enable OpenGL support */
+#define SDL_VIDEO_OPENGL 1
+/* #undef SDL_VIDEO_OPENGL_ES */
+/* #undef SDL_VIDEO_OPENGL_ES2 */
+/* #undef SDL_VIDEO_OPENGL_BGL */
+/* #undef SDL_VIDEO_OPENGL_CGL */
+/* #undef SDL_VIDEO_OPENGL_EGL */
+/* #undef SDL_VIDEO_OPENGL_GLX */
+/* #undef SDL_VIDEO_OPENGL_WGL */
+/* #undef SDL_VIDEO_OPENGL_OSMESA */
+/* #undef SDL_VIDEO_OPENGL_OSMESA_DYNAMIC */
+
+/* Enable Vulkan support */
+/* #undef SDL_VIDEO_VULKAN */
+
+/* Enable system power support */
+/* #undef SDL_POWER_LINUX */
+/* #undef SDL_POWER_WINDOWS */
+/* #undef SDL_POWER_MACOSX */
+/* #undef SDL_POWER_HAIKU */
+/* #undef SDL_POWER_ANDROID */
+/* #undef SDL_POWER_EMSCRIPTEN */
+/* #undef SDL_POWER_HARDWIRED */
+
+/* Enable system filesystem support */
+/* #undef SDL_FILESYSTEM_HAIKU */
+/* #undef SDL_FILESYSTEM_COCOA */
+/* #undef SDL_FILESYSTEM_DUMMY */
+/* #undef SDL_FILESYSTEM_UNIX */
+/* #undef SDL_FILESYSTEM_WINDOWS */
+#define SDL_FILESYSTEM_AMIGAOS4 1
+/* #undef SDL_FILESYSTEM_NACL */
+/* #undef SDL_FILESYSTEM_ANDROID */
+/* #undef SDL_FILESYSTEM_EMSCRIPTEN */
+
+/* Enable assembly routines */
+#define SDL_ASSEMBLY_ROUTINES 1
+#define SDL_ALTIVEC_BLITTERS 1
+
+/* Enable ime support */
+/* #undef SDL_USE_IME */
+
+/* Enable dynamic udev support */
+/* #undef SDL_UDEV_DYNAMIC */
+
+/* Enable dynamic libsamplerate support */
+/* #undef SDL_LIBSAMPLERATE_DYNAMIC */
+
+#endif /* SDL_config_amigaos4_h_ */

--- a/include/SDL_config_amigaos4.h
+++ b/include/SDL_config_amigaos4.h
@@ -174,7 +174,7 @@
 /* #undef HAVE_POLL */
 
 
-#define HAVE_ALTIVEC_H 1
+/*#define HAVE_ALTIVEC_H 1*/
 /* #undef HAVE_DBUS_DBUS_H */
 /* #undef HAVE_FCITX_FRONTEND_H */
 /* #undef HAVE_IBUS_IBUS_H */
@@ -389,7 +389,7 @@
 
 /* Enable assembly routines */
 #define SDL_ASSEMBLY_ROUTINES 1
-#define SDL_ALTIVEC_BLITTERS 1
+/*#define SDL_ALTIVEC_BLITTERS 1*/
 
 /* Enable ime support */
 /* #undef SDL_USE_IME */

--- a/test/Makefile.amigaos4
+++ b/test/Makefile.amigaos4
@@ -2,7 +2,7 @@
 
 CC		= ppc-amigaos-gcc
 CFLAGS	= -g -O2 -Wall -g -I../include
-LIBS	= -L.. -lSDL2 -lpthread -lGL -lm
+LIBS	= -L.. -lSDL2 -lpthread
 
 TARGETS = \
 	checkkeys \

--- a/test/Makefile.amigaos4
+++ b/test/Makefile.amigaos4
@@ -1,0 +1,282 @@
+# Makefile to build the AmigaOS4 SDL tests
+
+CC		= ppc-amigaos-gcc
+CFLAGS	= -g -O2 -Wall -g -I../include
+LIBS	= -L.. -lSDL2 -lpthread -lGL -lm
+
+TARGETS = \
+	checkkeys \
+	controllermap \
+	helloworld \
+	loopwave \
+	loopwavequeue \
+	sdl2benchmark \
+	testatomic \
+	testaudiocapture \
+	testaudiohotplug \
+	testaudioinfo \
+	testautomation \
+	testbounds \
+	testcustomcursor \
+	testdisplayinfo \
+	testdraw2 \
+	testdrawchessboard \
+	testdropfile \
+	testerror \
+	testfile \
+	testfilesystem \
+	testgamecontroller \
+	testgesture \
+	testgl2 \
+	testgles \
+	testgles2 \
+	testhaptic \
+	testhittesting \
+	testhotplug \
+	testiconv \
+	testime \
+	testintersections \
+	testjoystick \
+	testkeys \
+	testloadso \
+	testlock \
+	testmessage \
+	testmultiaudio \
+	testnative \
+	testoverlay2 \
+	testplatform \
+	testpower \
+	testqsort \
+	testrelative \
+	testrendercopyex \
+	testrendertarget \
+	testresample \
+	testrumble \
+	testscale \
+	testsem \
+	testsensor \
+	testshader \
+	testshape \
+	testsprite2 \
+	testspriteminimal \
+	teststreaming \
+	testthread \
+	testtimer \
+	testver \
+	testviewport \
+	testvulkan \
+	testwm2 \
+	testyuv \
+	torturethread \
+	
+all: $(TARGETS)
+
+checkkeys: checkkeys.o
+	$(CC) -o $@ $^ $(LIBS)
+
+helloworld: helloworld.o
+	$(CC) -o $@ $^ $(LIBS)
+
+loopwave: loopwave.o
+	$(CC) -o $@ $^ $(LIBS)
+
+loopwavequeue: loopwavequeue.o
+	$(CC) -o $@ $^ $(LIBS)
+
+sdl2benchmark: sdl2benchmark.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testresample: testresample.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testaudioinfo: testaudioinfo.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testautomation: testautomation.o \
+		      testautomation_audio.o \
+		      testautomation_clipboard.o \
+		      testautomation_events.o \
+		      testautomation_keyboard.o \
+		      testautomation_main.o \
+		      testautomation_mouse.o \
+		      testautomation_pixels.o \
+		      testautomation_platform.o \
+		      testautomation_rect.o \
+		      testautomation_render.o \
+		      testautomation_rwops.o \
+		      testautomation_sdltest.o \
+		      testautomation_stdlib.o \
+		      testautomation_surface.o \
+		      testautomation_syswm.o \
+		      testautomation_timer.o \
+		      testautomation_video.o \
+		      testautomation_hints.o
+	$(CC) -o $@ $^ $(LIBS) 
+
+testmultiaudio: testmultiaudio.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testaudiohotplug: testaudiohotplug.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testaudiocapture: testaudiocapture.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testatomic: testatomic.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testintersections: testintersections.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testrelative: testrelative.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testhittesting: testhittesting.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testdraw2: testdraw2.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testdrawchessboard: testdrawchessboard.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testdropfile: testdropfile.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testerror: testerror.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testfile: testfile.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testgamecontroller: testgamecontroller.o
+	$(CC) -o $@ $^ $(LIBS)
+ 
+testgesture: testgesture.o
+	$(CC) -o $@ $^ $(LIBS)
+ 
+testgl2: testgl2.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testgles: testgles.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testgles2: testgles2.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testhaptic: testhaptic.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testhotplug: testhotplug.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testrumble: testrumble.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testthread: testthread.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testiconv: testiconv.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testime: testime.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testjoystick: testjoystick.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testkeys: testkeys.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testloadso: testloadso.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testlock: testlock.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testnative: testnative.o testnativeamigaos4.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testoverlay2: testoverlay2.o testyuv_cvt.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testplatform: testplatform.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testpower: testpower.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testfilesystem: testfilesystem.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testrendertarget: testrendertarget.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testscale: testscale.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testsem: testsem.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testsensor: testsensor.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testshader: testshader.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testshape: testshape.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testsprite2: testsprite2.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testspriteminimal: testspriteminimal.o
+	$(CC) -o $@ $^ $(LIBS)
+
+teststreaming: teststreaming.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testtimer: testtimer.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testver: testver.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testviewport: testviewport.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testwm2: testwm2.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testyuv: testyuv.o testyuv_cvt.o
+	$(CC) -o $@ $^ $(LIBS)
+
+torturethread: torturethread.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testrendercopyex: testrendercopyex.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testmessage: testmessage.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testdisplayinfo: testdisplayinfo.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testqsort: testqsort.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testbounds: testbounds.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testcustomcursor: testcustomcursor.o
+	$(CC) -o $@ $^ $(LIBS)
+
+controllermap: controllermap.o
+	$(CC) -o $@ $^ $(LIBS)
+
+testvulkan: testvulkan.o
+	$(CC) -o $@ $^ $(LIBS)
+
+clean:
+	rm -f $(TARGETS) *.o


### PR DESCRIPTION
It can be used to build the static and shared library, and install them. The SDL_config_amigaos4.h header might need some tweaks, because I don't have the GLES2 headers. This should fix #24. 