### PR TITLE
Reset keyboard state during full screen toggle

### DIFF
--- a/src/video/amigaos4/SDL_os4events.c
+++ b/src/video/amigaos4/SDL_os4events.c
@@ -1,6 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2020 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -73,7 +73,7 @@ struct QualifierItem
 
 extern OS4_GlobalMouseState globalMouseState;
 
-void
+static void
 OS4_SyncKeyModifiers(_THIS)
 {
     int i;
@@ -472,6 +472,8 @@ OS4_HandleActivation(_THIS, struct MyIntuiMessage * imsg, SDL_bool activated)
     if (sdlwin) {
         if (activated) {
             SDL_SendWindowEvent(sdlwin, SDL_WINDOWEVENT_SHOWN, 0, 0);
+            OS4_SyncKeyModifiers(_this);
+
             if (SDL_GetKeyboardFocus() != sdlwin) {
                 SDL_SetKeyboardFocus(sdlwin);
                 // TODO: do we want to set mouse colors as in SDL1?

--- a/src/video/amigaos4/SDL_os4events.h
+++ b/src/video/amigaos4/SDL_os4events.h
@@ -1,6 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2020 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -24,7 +24,6 @@
 #define _SDL_os4events_h
 
 extern void OS4_PumpEvents(_THIS);
-extern void OS4_SyncKeyModifiers(_THIS);
 
 #endif /* _SDL_os4events_h */
 

--- a/src/video/amigaos4/SDL_os4window.c
+++ b/src/video/amigaos4/SDL_os4window.c
@@ -1,6 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2020 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -402,8 +402,6 @@ OS4_CreateSystemWindow(_THIS, SDL_Window * window, SDL_VideoDisplay * display)
         }
     }
 
-    OS4_SyncKeyModifiers(_this);
-
     return syswin;
 }
 
@@ -760,6 +758,9 @@ OS4_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
                             width, height);
                     }
                 }
+
+                dprintf("Resetting keyboard\n");
+                SDL_ResetKeyboard();
             }
         }
     }


### PR DESCRIPTION
Fix will potentially help in cases where key up event (like ALT+ENTER) is lost during window re-creation.