### PR TITLE
Potential issue in src/video/windows/SDL_windowsevents.c: Unchecked return from initialization function

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -460,7 +460,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_ACTIVATE:
         {
-            POINT cursorPos;
+            POINT cursorPos = {};
             BOOL minimized;
 
             minimized = HIWORD(wParam);
@@ -632,7 +632,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                     WIN_CheckRawMouseButtons(rawmouse->usButtonFlags, data);
                 } else if (isCapture) {
                     /* we check for where Windows thinks the system cursor lives in this case, so we don't really lose mouse accel, etc. */
-                    POINT pt;
+                    POINT pt = {};
                     RECT hwndRect;
                     HWND currentHnd;
 
@@ -674,7 +674,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         if (SDL_GetMouseFocus() == data->window && !SDL_GetMouse()->relative_mode && !(data->window->flags & SDL_WINDOW_MOUSE_CAPTURE)) {
             if (!IsIconic(hwnd)) {
                 SDL_Mouse *mouse;
-                POINT cursorPos;
+                POINT cursorPos = {};
                 GetCursorPos(&cursorPos);
                 ScreenToClient(hwnd, &cursorPos);
                 mouse = SDL_GetMouse();
@@ -868,7 +868,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_WINDOWPOSCHANGED:
         {
-            RECT rect;
+            RECT rect = {};
             int x, y;
             int w, h;
 
@@ -982,7 +982,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             SDL_bool isstack;
             PTOUCHINPUT inputs = SDL_small_alloc(TOUCHINPUT, num_inputs, &isstack);
             if (data->videodata->GetTouchInputInfo((HTOUCHINPUT)lParam, num_inputs, inputs, sizeof(TOUCHINPUT))) {
-                RECT rect;
+                RECT rect = {};
                 float x, y;
 
                 if (!GetClientRect(hwnd, &rect) ||


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**7 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `ScreenToClient@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L496
**Issue in**: _cursorPos_

**Code extract**:

```cpp
                }

                GetCursorPos(&cursorPos);
                ScreenToClient(hwnd, &cursorPos); <------ HERE
                SDL_SendMouseMotion(data->window, 0, 0, cursorPos.x, cursorPos.y);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `ScreenToClient@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L641
**Issue in**: _pt_

**Code extract**:

```cpp

                    GetCursorPos(&pt);
                    currentHnd = WindowFromPoint(pt);
                    ScreenToClient(hwnd, &pt); <------ HERE
                    GetClientRect(hwnd, &hwndRect);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `GetClientRect@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L642
**Issue in**: _hwndRect_

**Code extract**:

```cpp
                    GetCursorPos(&pt);
                    currentHnd = WindowFromPoint(pt);
                    ScreenToClient(hwnd, &pt);
                    GetClientRect(hwnd, &hwndRect); <------ HERE

                    /* if in the window, WM_MOUSEMOVE, etc, will cover it. */
```

**How can I fix it?** 
Correct reference usage found in `src/video/windows/SDL_windowswindow.c` at line `958`.
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L958
**Code extract**:

```cpp
                }
            }
        } else {
            if (GetClientRect(data->hwnd, &rect) && !IsRectEmpty(&rect)) { <------ HERE
                ClientToScreen(data->hwnd, (LPPOINT) & rect);
                ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
```


---
**Instance 4**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `ScreenToClient@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L679
**Issue in**: _cursorPos_

**Code extract**:

```cpp
                SDL_Mouse *mouse;
                POINT cursorPos;
                GetCursorPos(&cursorPos);
                ScreenToClient(hwnd, &cursorPos); <------ HERE
                mouse = SDL_GetMouse();
                if (!mouse->was_touch_mouse_events) { /* we're not a touch handler causing a mouse leave? */
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 5**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `GetWindowRect@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L799
**Issue in**: _size_

**Code extract**:

```cpp
            }

            /* Get the current position of our window */
            GetWindowRect(hwnd, &size); <------ HERE
            x = size.left;
            y = size.top;
```

**How can I fix it?** 
Correct reference usage found in `src/video/windows/SDL_windowswindow.c` at line `939`.
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L939
**Code extract**:

```cpp
    if ((mouse->relative_mode || (window->flags & SDL_WINDOW_INPUT_GRABBED)) &&
        (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
        if (mouse->relative_mode && !mouse->relative_mode_warp) {
            if (GetWindowRect(data->hwnd, &rect)) { <------ HERE
                LONG cx, cy;

```


---
**Instance 6**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `ClientToScreen@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L882
**Issue in**: _rect_

**Code extract**:

```cpp
            if (!GetClientRect(hwnd, &rect) || IsRectEmpty(&rect)) {
                break;
            }
            ClientToScreen(hwnd, (LPPOINT) & rect); <------ HERE
            ClientToScreen(hwnd, (LPPOINT) & rect + 1);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 7**
File : `src/video/windows/SDL_windowsevents.c` 
Enclosing Function : `WIN_WindowProc@16`
Function : `ClientToScreen@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowsevents.c#L995
**Issue in**: _rect_

**Code extract**:

```cpp
                    }
                    break;
                }
                ClientToScreen(hwnd, (LPPOINT) & rect); <------ HERE
                ClientToScreen(hwnd, (LPPOINT) & rect + 1);
                rect.top *= 100;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
