### PR TITLE
Potential issue in src/video/windows/SDL_windowswindow.c: Unchecked return from initialization function

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -285,7 +285,7 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
         SDL_SetKeyboardFocus(data->window);
 
         if (window->flags & SDL_WINDOW_INPUT_GRABBED) {
-            RECT rect;
+            RECT rect = {};
             GetClientRect(hwnd, &rect);
             ClientToScreen(hwnd, (LPPOINT) & rect);
             ClientToScreen(hwnd, (LPPOINT) & rect + 1);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**4 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `src/video/windows/SDL_windowswindow.c` 
Enclosing Function : `SetupWindowData`
Function : `GetClientRect@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L289
**Issue in**: _rect_

**Code extract**:

```cpp

        if (window->flags & SDL_WINDOW_INPUT_GRABBED) {
            RECT rect;
            GetClientRect(hwnd, &rect); <------ HERE
            ClientToScreen(hwnd, (LPPOINT) & rect);
            ClientToScreen(hwnd, (LPPOINT) & rect + 1);
```

**How can I fix it?** 
Correct reference usage found in `src/video/windows/SDL_windowswindow.c` at line `958`.
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L958
**Code extract**:

```cpp
                }
            }
        } else {
            if (GetClientRect(data->hwnd, &rect) && !IsRectEmpty(&rect)) { <------ HERE
                ClientToScreen(data->hwnd, (LPPOINT) & rect);
                ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
```


---
**Instance 2**
File : `src/video/windows/SDL_windowswindow.c` 
Enclosing Function : `SetupWindowData`
Function : `ClientToScreen@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L290
**Issue in**: _rect_

**Code extract**:

```cpp
        if (window->flags & SDL_WINDOW_INPUT_GRABBED) {
            RECT rect;
            GetClientRect(hwnd, &rect);
            ClientToScreen(hwnd, (LPPOINT) & rect); <------ HERE
            ClientToScreen(hwnd, (LPPOINT) & rect + 1);
            ClipCursor(&rect);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `src/video/windows/SDL_windowswindow.c` 
Enclosing Function : `WIN_GetWindowBordersSize`
Function : `GetClientRect@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L524
**Issue in**: _rcClient_

**Code extract**:

```cpp

    /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
     * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
    GetClientRect(hwnd, &rcClient); <------ HERE
    GetWindowRect(hwnd, &rcWindow);

```

**How can I fix it?** 
Correct reference usage found in `src/video/windows/SDL_windowswindow.c` at line `958`.
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L958
**Code extract**:

```cpp
                }
            }
        } else {
            if (GetClientRect(data->hwnd, &rect) && !IsRectEmpty(&rect)) { <------ HERE
                ClientToScreen(data->hwnd, (LPPOINT) & rect);
                ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
```


---
**Instance 4**
File : `src/video/windows/SDL_windowswindow.c` 
Enclosing Function : `WIN_GetWindowBordersSize`
Function : `GetWindowRect@8` 
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L525
**Issue in**: _rcWindow_

**Code extract**:

```cpp
    /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
     * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
    GetClientRect(hwnd, &rcClient);
    GetWindowRect(hwnd, &rcWindow); <------ HERE

    /* convert the top/left values to make them relative to
```

**How can I fix it?** 
Correct reference usage found in `src/video/windows/SDL_windowswindow.c` at line `939`.
https://github.com/AmigaPorts/SDL/blob/6ae22b7e453904d4125f7fd2143d574017a8f05a/src/video/windows/SDL_windowswindow.c#L939
**Code extract**:

```cpp
    if ((mouse->relative_mode || (window->flags & SDL_WINDOW_INPUT_GRABBED)) &&
        (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
        if (mouse->relative_mode && !mouse->relative_mode_warp) {
            if (GetWindowRect(data->hwnd, &rect)) { <------ HERE
                LONG cx, cy;

```

